### PR TITLE
Implement operator Phase 4: Job creation and lifecycle management

### DIFF
--- a/cmd/shepherd/operator.go
+++ b/cmd/shepherd/operator.go
@@ -26,6 +26,7 @@ type OperatorCmd struct {
 	LeaderElection     bool   `help:"Enable leader election" default:"false" env:"SHEPHERD_LEADER_ELECTION"`
 	AllowedRunnerImage string `help:"Allowed runner image" required:"" env:"SHEPHERD_RUNNER_IMAGE"`
 	RunnerSecretName   string `help:"Runner app key secret" default:"shepherd-runner-app-key" env:"SHEPHERD_RUNNER_SECRET"`
+	InitImage          string `help:"Init container image" default:"shepherd-init:latest" env:"SHEPHERD_INIT_IMAGE"`
 }
 
 func (c *OperatorCmd) Run(_ *CLI) error {
@@ -35,5 +36,6 @@ func (c *OperatorCmd) Run(_ *CLI) error {
 		LeaderElection:     c.LeaderElection,
 		AllowedRunnerImage: c.AllowedRunnerImage,
 		RunnerSecretName:   c.RunnerSecretName,
+		InitImage:          c.InitImage,
 	})
 }

--- a/internal/controller/agenttask_controller_test.go
+++ b/internal/controller/agenttask_controller_test.go
@@ -45,6 +45,7 @@ var _ = Describe("AgentTask Controller", func() {
 			Recorder:           events.NewFakeRecorder(10),
 			AllowedRunnerImage: "shepherd-runner:latest",
 			RunnerSecretName:   "shepherd-runner-app-key",
+			InitImage:          "shepherd-init:latest",
 		}
 	})
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -48,6 +48,7 @@ type Options struct {
 	LeaderElection     bool
 	AllowedRunnerImage string
 	RunnerSecretName   string
+	InitImage          string
 }
 
 // Run starts the operator with the given options.
@@ -76,6 +77,7 @@ func Run(opts Options) error {
 		Recorder:           mgr.GetEventRecorder("shepherd-operator"),
 		AllowedRunnerImage: opts.AllowedRunnerImage,
 		RunnerSecretName:   opts.RunnerSecretName,
+		InitImage:          opts.InitImage,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setting up controller: %w", err)
 	}

--- a/thoughts/plans/2026-01-27-operator-implementation.md
+++ b/thoughts/plans/2026-01-27-operator-implementation.md
@@ -1000,6 +1000,123 @@ Extend envtest tests:
 - [ ] Review Job spec matches design doc (init container, main container, volumes)
 - [ ] Owner references ensure garbage collection
 
+**Pause for manual review before Phase 4.5.**
+
+---
+
+## Phase 4.5: Init Container Context Decompression
+
+### Overview
+
+Extend the init container's responsibilities and the Job spec to handle gzip-decompressed context. The design doc specifies that the API gzip-compresses the context field before creating the CRD. Currently `SHEPHERD_TASK_DESCRIPTION` is passed as a plain env var to the runner, which won't scale to large prompts or compressed context. The init container already runs before the main container and has write access to a shared volume — extend it to also write task input files.
+
+### Rationale
+
+- **Design doc compliance**: `docs/research/2026-01-27-shepherd-design.md` line 335 specifies gzip compression of the context field
+- **Env var size limits**: Large prompts + context can exceed practical env var sizes (~1-2MB due to pod spec in etcd)
+- **File-based input is standard**: More robust than env vars for multi-line text with special characters
+- **Init container already exists**: Zero additional pod overhead — just extend its responsibilities
+
+### Changes Required
+
+#### 1. Update Job Builder
+
+**File**: `internal/controller/job_builder.go`
+
+Changes:
+- Remove `SHEPHERD_TASK_DESCRIPTION` from runner container env vars
+- Add `TASK_DESCRIPTION`, `TASK_CONTEXT`, and `CONTEXT_ENCODING` to init container env vars
+- Add `SHEPHERD_TASK_FILE=/task/description.txt` and `SHEPHERD_CONTEXT_FILE=/task/context.txt` to runner container env vars
+- Add `task-files` emptyDir volume, mounted read-write in init container and read-only in runner
+
+Init container env changes:
+```go
+initEnv := []corev1.EnvVar{
+    {Name: "REPO_URL", Value: task.Spec.Repo.URL},
+    {Name: "TASK_DESCRIPTION", Value: task.Spec.Task.Description},
+}
+if task.Spec.Repo.Ref != "" {
+    initEnv = append(initEnv, corev1.EnvVar{Name: "REPO_REF", Value: task.Spec.Repo.Ref})
+}
+if task.Spec.Task.Context != "" {
+    initEnv = append(initEnv, corev1.EnvVar{
+        Name: "TASK_CONTEXT", Value: task.Spec.Task.Context,
+    })
+}
+if task.Spec.Task.ContextEncoding != "" {
+    initEnv = append(initEnv, corev1.EnvVar{
+        Name: "CONTEXT_ENCODING", Value: task.Spec.Task.ContextEncoding,
+    })
+}
+```
+
+Runner container env changes:
+```go
+// Remove SHEPHERD_TASK_DESCRIPTION, add file paths instead:
+{Name: "SHEPHERD_TASK_FILE", Value: "/task/description.txt"},
+{Name: "SHEPHERD_CONTEXT_FILE", Value: "/task/context.txt"},
+```
+
+Volume changes:
+```yaml
+volumes:
+  - name: task-files
+    emptyDir: {}
+
+initContainers:
+  - name: github-auth
+    volumeMounts:
+      - name: task-files
+        mountPath: /task
+
+containers:
+  - name: runner
+    volumeMounts:
+      - name: task-files
+        mountPath: /task
+        readOnly: true
+```
+
+#### 2. Update Job Builder Tests
+
+**File**: `internal/controller/job_builder_test.go`
+
+- Verify init container env includes `TASK_DESCRIPTION` and `TASK_CONTEXT` (when set)
+- Verify runner env includes `SHEPHERD_TASK_FILE` and `SHEPHERD_CONTEXT_FILE`
+- Verify runner env does NOT include `SHEPHERD_TASK_DESCRIPTION`
+- Verify `task-files` volume exists and is mounted correctly (init: read-write, runner: read-only)
+- Verify `TASK_CONTEXT` and `CONTEXT_ENCODING` are omitted when spec fields are empty
+
+#### 3. Update Integration Tests
+
+**File**: `internal/controller/agenttask_controller_test.go`
+
+- Verify created Job has the `task-files` volume
+- Verify runner container mounts `/task` read-only
+
+### Out of Scope
+
+- Init container binary implementation (separate image build plan)
+- Runner image entrypoint updates (separate image build plan)
+- This phase only updates the Job spec generation in the operator
+
+### Phase Ordering
+
+This phase must complete before implementing the API, since the API creates CRDs with gzip context and the Job spec must match the expected contract.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] `make test` passes all tests
+- [ ] `go vet ./...` clean
+- [ ] Job builder unit tests verify init container receives `TASK_DESCRIPTION`, `TASK_CONTEXT`, `CONTEXT_ENCODING`
+- [ ] Job builder unit tests verify runner receives `SHEPHERD_TASK_FILE` and `SHEPHERD_CONTEXT_FILE`
+- [ ] Job builder unit tests verify runner does NOT receive `SHEPHERD_TASK_DESCRIPTION`
+- [ ] Job builder unit tests verify `task-files` volume mounts
+
+#### Manual Verification:
+- [ ] Review Job spec matches updated contract (init writes files, runner reads files)
+
 **Pause for manual review before Phase 5.**
 
 ---


### PR DESCRIPTION
## Summary

- Reconciler creates K8s Jobs from AgentTask resources with init container (GitHub auth) and main container (runner)
- Monitors Job status and updates CRD conditions through the full lifecycle: Pending → Running → Succeeded/Failed
- Adds `GenerationChangedPredicate` to skip reconciles on status-only updates
- Applies code review fixes: configurable init image, fail-fast on build errors, job name length validation
- Adds Phase 4.5 to implementation plan for init container context decompression (file-based task input, gzip handling)

## Changes

**Job Builder** (`internal/controller/job_builder.go` — new):
- Constructs Job specs with init + main containers, volumes, env vars, owner references
- Validates runner and init images are configured (operator-level security)
- Validates job name stays within 63-character DNS limit
- Sets `backoffLimit: 0` and `activeDeadlineSeconds` from spec timeout

**Reconciler** (`internal/controller/agenttask_controller.go`):
- Creates Job on second reconcile (after Pending condition is set)
- Monitors Job conditions for completion/failure
- Sets `status.jobName`, `status.startTime`, `status.completionTime`
- Marks task Failed immediately on configuration errors (no infinite retry)
- `markSucceeded()` / `markFailed()` helpers for terminal state transitions

**Operator wiring** (`pkg/operator/operator.go`, `cmd/shepherd/operator.go`):
- Threads `InitImage` (`SHEPHERD_INIT_IMAGE`) through CLI → Options → Reconciler → Job

**Tests** (31 total — 22 unit + 9 integration):
- Job builder: name, labels, backoff, timeout, env vars, image, owner ref, resources, volumes, mounts, secret, restart policy, service account, configurable init image, empty image validation, name length validation
- Integration (envtest): Pending → Running → Succeeded, Pending → Running → Failed, terminal state skip, deleted resource, idempotent job creation, REPO_REF env var propagation

**Plan** (`thoughts/plans/2026-01-27-operator-implementation.md`):
- Added Phase 4.5: init container context decompression — move task description from env var to file, handle gzip context, add `task-files` shared volume

## Test plan

- [x] `go build ./...` compiles
- [x] `go vet ./...` clean
- [x] `go test ./internal/controller/... -v -count=1` — all 31 tests pass
- [ ] Manual: review Job spec matches design doc
- [ ] Manual: verify owner references enable garbage collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)