### PR TITLE
Standardize JSON tags to use uppercase acronyms

### DIFF
--- a/api/v1alpha1/agenttask_types.go
+++ b/api/v1alpha1/agenttask_types.go
@@ -25,7 +25,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[?(@.type=="Succeeded")].reason`
-// +kubebuilder:printcolumn:name="PR",type=string,JSONPath=`.status.result.prUrl`,priority=1
+// +kubebuilder:printcolumn:name="PR",type=string,JSONPath=`.status.result.prURL`,priority=1
 // +kubebuilder:printcolumn:name="Claim",type=string,JSONPath=`.status.sandboxClaimName`
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
@@ -123,7 +123,7 @@ type AgentTaskStatus struct {
 }
 
 type TaskResult struct {
-	PRUrl string `json:"prUrl,omitempty"`
+	PRURL string `json:"prURL,omitempty"`
 	Error string `json:"error,omitempty"`
 }
 

--- a/config/crd/bases/toolkit.shepherd.io_agenttasks.yaml
+++ b/config/crd/bases/toolkit.shepherd.io_agenttasks.yaml
@@ -18,7 +18,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Succeeded")].reason
       name: Status
       type: string
-    - jsonPath: .status.result.prUrl
+    - jsonPath: .status.result.prURL
       name: PR
       priority: 1
       type: string
@@ -272,7 +272,7 @@ spec:
                 properties:
                   error:
                     type: string
-                  prUrl:
+                  prURL:
                     type: string
                 type: object
               sandboxClaimName:

--- a/pkg/api/handler_status.go
+++ b/pkg/api/handler_status.go
@@ -102,7 +102,7 @@ func (h *taskHandler) updateTaskStatus(w http.ResponseWriter, r *http.Request) {
 		switch req.Event {
 		case EventCompleted:
 			if prURL, ok := req.Details["pr_url"].(string); ok {
-				task.Status.Result.PRUrl = prURL
+				task.Status.Result.PRURL = prURL
 			}
 		case EventFailed:
 			if errMsg, ok := req.Details["error"].(string); ok {

--- a/pkg/api/handler_status_test.go
+++ b/pkg/api/handler_status_test.go
@@ -123,7 +123,7 @@ func TestUpdateTaskStatus_CompletedWithPRUrl(t *testing.T) {
 	var updated toolkitv1alpha1.AgentTask
 	err := h.client.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "task-abc"}, &updated)
 	require.NoError(t, err)
-	assert.Equal(t, "https://github.com/org/repo/pull/1", updated.Status.Result.PRUrl)
+	assert.Equal(t, "https://github.com/org/repo/pull/1", updated.Status.Result.PRURL)
 
 	notified := apimeta.FindStatusCondition(updated.Status.Conditions, toolkitv1alpha1.ConditionNotified)
 	require.NotNil(t, notified)

--- a/pkg/api/handler_tasks.go
+++ b/pkg/api/handler_tasks.go
@@ -90,24 +90,24 @@ func (h *taskHandler) createTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.Callback == "" {
-		writeError(w, http.StatusBadRequest, "callbackUrl is required", "")
+		writeError(w, http.StatusBadRequest, "callbackURL is required", "")
 		return
 	}
 
 	// Validate callback URL
 	parsedURL, err := url.Parse(req.Callback)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid callbackUrl", err.Error())
+		writeError(w, http.StatusBadRequest, "invalid callbackURL", err.Error())
 		return
 	}
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-		writeError(w, http.StatusBadRequest, "invalid callbackUrl scheme", "must be http or https")
+		writeError(w, http.StatusBadRequest, "invalid callbackURL scheme", "must be http or https")
 		return
 	}
 	// Validate hostname is non-empty
 	hostname := parsedURL.Hostname()
 	if hostname == "" {
-		writeError(w, http.StatusBadRequest, "invalid callbackUrl host", "hostname is empty")
+		writeError(w, http.StatusBadRequest, "invalid callbackURL host", "hostname is empty")
 		return
 	}
 	// Block well-known metadata IPs and localhost
@@ -120,7 +120,7 @@ func (h *taskHandler) createTask(w http.ResponseWriter, r *http.Request) {
 		"0.0.0.0":         true,
 	}
 	if blockedHosts[hostname] {
-		writeError(w, http.StatusBadRequest, "invalid callbackUrl host", "blocked host")
+		writeError(w, http.StatusBadRequest, "invalid callbackURL host", "blocked host")
 		return
 	}
 
@@ -358,7 +358,7 @@ func extractStatus(task *toolkitv1alpha1.AgentTask) TaskStatusSummary {
 		Phase:            phase,
 		Message:          message,
 		SandboxClaimName: task.Status.SandboxClaimName,
-		PRUrl:            task.Status.Result.PRUrl,
+		PRURL:            task.Status.Result.PRURL,
 		Error:            task.Status.Result.Error,
 	}
 }

--- a/pkg/api/handler_tasks_test.go
+++ b/pkg/api/handler_tasks_test.go
@@ -226,7 +226,7 @@ func TestCreateTask_MissingCallbackURL(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	var errResp ErrorResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
-	assert.Equal(t, "callbackUrl is required", errResp.Error)
+	assert.Equal(t, "callbackURL is required", errResp.Error)
 }
 
 func TestCreateTask_MissingSandboxTemplateName(t *testing.T) {
@@ -475,14 +475,14 @@ func TestExtractStatus_Terminal(t *testing.T) {
 				},
 			},
 			Result: toolkitv1alpha1.TaskResult{
-				PRUrl: "https://github.com/org/repo/pull/1",
+				PRURL: "https://github.com/org/repo/pull/1",
 			},
 		},
 	}
 	status := extractStatus(task)
 	assert.Equal(t, "Succeeded", status.Phase)
 	assert.Equal(t, "Task completed successfully", status.Message)
-	assert.Equal(t, "https://github.com/org/repo/pull/1", status.PRUrl)
+	assert.Equal(t, "https://github.com/org/repo/pull/1", status.PRURL)
 }
 
 func TestTaskToResponse_CompletionTime(t *testing.T) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -28,7 +28,7 @@ const (
 type CreateTaskRequest struct {
 	Repo     RepoRequest       `json:"repo"`
 	Task     TaskRequest       `json:"task"`
-	Callback string            `json:"callbackUrl"`
+	Callback string            `json:"callbackURL"`
 	Runner   *RunnerConfig     `json:"runner,omitempty"`
 	Labels   map[string]string `json:"labels,omitempty"`
 }
@@ -61,7 +61,7 @@ type TaskResponse struct {
 	Namespace      string            `json:"namespace"`
 	Repo           RepoRequest       `json:"repo"`
 	Task           TaskRequest       `json:"task"`
-	CallbackURL    string            `json:"callbackUrl"`
+	CallbackURL    string            `json:"callbackURL"`
 	Status         TaskStatusSummary `json:"status"`
 	CreatedAt      string            `json:"createdAt"`
 	CompletionTime *string           `json:"completionTime,omitempty"`
@@ -72,7 +72,7 @@ type TaskStatusSummary struct {
 	Phase            string `json:"phase"`
 	Message          string `json:"message"`
 	SandboxClaimName string `json:"sandboxClaimName,omitempty"`
-	PRUrl            string `json:"prUrl,omitempty"`
+	PRURL            string `json:"prURL,omitempty"`
 	Error            string `json:"error,omitempty"`
 }
 
@@ -85,7 +85,7 @@ type StatusUpdateRequest struct {
 
 // CallbackPayload is the JSON body sent to adapters.
 type CallbackPayload struct {
-	TaskID  string         `json:"taskId"`
+	TaskID  string         `json:"taskID"`
 	Event   string         `json:"event"` // started, progress, completed, failed
 	Message string         `json:"message"`
 	Details map[string]any `json:"details,omitempty"`

--- a/pkg/api/watcher.go
+++ b/pkg/api/watcher.go
@@ -171,8 +171,8 @@ func (w *statusWatcher) handleTerminalTransition(ctx context.Context, task *tool
 		Message: succeededCond.Message,
 		Details: map[string]any{},
 	}
-	if fresh.Status.Result.PRUrl != "" {
-		payload.Details["pr_url"] = fresh.Status.Result.PRUrl
+	if fresh.Status.Result.PRURL != "" {
+		payload.Details["pr_url"] = fresh.Status.Result.PRURL
 	}
 	if fresh.Status.Result.Error != "" {
 		payload.Details["error"] = fresh.Status.Result.Error

--- a/pkg/api/watcher_test.go
+++ b/pkg/api/watcher_test.go
@@ -286,7 +286,7 @@ func TestWatcher_PRUrlIncludedInCallbackDetails(t *testing.T) {
 			Status: metav1.ConditionTrue,
 			Reason: toolkitv1alpha1.ReasonSucceeded,
 		},
-	}, toolkitv1alpha1.TaskResult{PRUrl: "https://github.com/org/repo/pull/42"})
+	}, toolkitv1alpha1.TaskResult{PRURL: "https://github.com/org/repo/pull/42"})
 
 	w, _ := newTestWatcher(task)
 	w.handleTerminalTransition(context.Background(), task)


### PR DESCRIPTION
## Summary

- Rename JSON tags and Go field names to use uppercase acronyms (`URL`, `ID`) consistently across CRD types and API types (fixes #26)
- `callbackUrl` → `callbackURL`, `prUrl` → `prURL`, `taskId` → `taskID`
- Regenerate CRD manifests via `make manifests`

**BREAKING CHANGE**: Existing API clients sending `callbackUrl`, `prUrl`, `taskId` must update to `callbackURL`, `prURL`, `taskID`.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes all tests
- [x] `make manifests` regenerates CRD YAML with updated JSON tags
- [x] `grep -r 'callbackUrl\|prUrl\|taskId' --include='*.go' --include='*.yaml'` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)